### PR TITLE
Remove timed out waiting process from queue

### DIFF
--- a/src/lock.js
+++ b/src/lock.js
@@ -203,6 +203,7 @@ module.exports = function () {
 				setTimeout(function () {
 					if (!terminated) {
 						terminated = true;
+						lock.queue.shift();
 						if (timeoutCallback) {
 							timeoutCallback.call(scope);
 						}


### PR DESCRIPTION
If a timeout occurs while waiting for the lock, the queued task has to be removed to not create a deadlock because the release on the remaining task will never be run.