### PR TITLE
Clean up queue after timeout to properly release lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
 	"bugs": "https://github.com/71104/rwlock/issues",
 	"license": "MIT",
 	"author": "Alberto La Rocca <a71104@gmail.com>",
+    "contributors": [{ "name" : "Christian Lerrahn",
+                       "email" : "git@penpal4u.net"}],
 	"files": [
 		"lib",
 		"LICENSE",

--- a/src/lock.js
+++ b/src/lock.js
@@ -108,6 +108,7 @@ module.exports = function () {
 				setTimeout(function () {
 					if (!terminated) {
 						terminated = true;
+                        lock.queue.shift();
 						if (timeoutCallback) {
 							timeoutCallback.call(options.scope);
 						}
@@ -203,6 +204,7 @@ module.exports = function () {
 				setTimeout(function () {
 					if (!terminated) {
 						terminated = true;
+                        lock.queue.shift();
 						if (timeoutCallback) {
 							timeoutCallback.call(scope);
 						}

--- a/test/all.js
+++ b/test/all.js
@@ -230,6 +230,29 @@ module.exports.readerTimeout = function (test) {
 	});
 };
 
+module.exports.readerTimeout = function (test) {
+	var lock = new ReadWriteLock();
+	lock.writeLock(function (release) {
+		lock.readLock(function (release) {
+			test.ok(false);
+			test.done();
+		}, {
+			timeout: 0
+		});
+		lock.readLock(function (release) {
+			test.ok(true);
+			test.done();
+		}, {
+			timeout: 20,
+			timeoutCallback: function () {
+				test.ok(false);
+				test.done();
+			}
+		});
+		setTimeout(release, 10);
+	});
+};
+
 module.exports.writerTimeoutAgainstAnotherWriter = function (test) {
 	var lock = new ReadWriteLock();
 	lock.writeLock(function (release) {
@@ -243,6 +266,30 @@ module.exports.writerTimeoutAgainstAnotherWriter = function (test) {
 				test.done();
 			}
 		});
+		setTimeout(release, 10);
+	});
+};
+
+module.exports.writerTimeoutAgainstAnotherWriterNewWriter = function (test) {
+	var lock = new ReadWriteLock();
+	lock.writeLock(function (release) {
+		lock.writeLock(function (release) {
+			test.ok(false);
+			test.done();
+		}, {
+			timeout: 0
+		});
+        lock.writeLock(function (release) {
+			test.ok(true);
+			test.done();
+		}, {
+			timeout: 20,
+            timeoutCallback: function() {
+                test.ok(false);
+                test.done();
+            }
+		});
+
 		setTimeout(release, 10);
 	});
 };


### PR DESCRIPTION
If a wait for a lock times out, the corresponding element is not removed but its release will never be called.